### PR TITLE
feat: move to timestamp-based period on mini TWAP

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,7 +6,7 @@ libs = ['lib']
 no_match_path = "contracts/*"
 solc_version = '0.8.18'
 optimizer = true
-optimizer_runs = 5_000
+optimizer_runs = 18_000
 viaIR = false
 eth_rpc_url = "https://eth-mainnet.g.alchemy.com/v2/vevMezCXoFshwV190wQcekYwQflctBeE"
 
@@ -14,9 +14,11 @@ eth_rpc_url = "https://eth-mainnet.g.alchemy.com/v2/vevMezCXoFshwV190wQcekYwQflc
 fork_block_number = 17237181
 
 [profile.ci_sizes]
+optimizer_runs = 18_000
 test = 'DO_NOT_COMPILE'
 
 [profile.ci_sizes_ir]
+optimizer_runs = 200
 test = 'DO_NOT_COMPILE'
 viaIR = true
 

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -5026,7 +5026,7 @@ contract PanopticPoolTest is PositionUtils {
             (priceArray, medianTick) = pp.getPriceArray();
             for (uint256 j = 0; j < 8; ++j) {
                 console2.log(expectedArray[j]);
-                console2.log(expectedArray[j+1]);
+                console2.log(expectedArray[j + 1]);
                 console2.log(priceArray[j]);
                 console2.log(block.timestamp);
                 console2.log(lastTimestamp);


### PR DESCRIPTION
Using the block timestamp instead of the block number to pace median TWAP updates allows us to deploy on chains with blocktimes other than 12 or variable blocktimes without having to make changes to any constants.