### PR TITLE
fix: typos in CollateralTracker

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -134,14 +134,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice a token can only be initialized once - which is done by the Panoptic pool.
     bool internal s_initialized;
 
-    /// @dev store whether the current collateral token is token0 of the AMM (true) or token1 (false).
-    bool internal s_underlyingIsToken0;
-
     /// @dev stores address of token0 from the underlying uniswap v3 pool.
     address internal s_univ3token0;
 
     /// @dev stores address of token1 from the underlying uniswap v3 pool.
     address internal s_univ3token1;
+
+    /// @dev store whether the current collateral token is token0 of the AMM (true) or token1 (false).
+    bool internal s_underlyingIsToken0;
 
     /*//////////////////////////////////////////////////////////////
                            PANOPTIC POOL DATA
@@ -228,7 +228,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice Initialize a new collateral tracker for a specific token corresponding to the Panoptic Pool being created by the factory that called it.
     /// @dev The factory calls this function to start a new collateral tracking system for the incoming token at 'underlyingToken'.
     /// The factory will do this for each of the two tokens being tracked. Thus, the collateral tracking system does not track *both* tokens at once.
-    /// @param underlyingToken the address of the token to track collateral corresponding to the Panoptic Pool being created by the factory calling this (as 'msg.sender').
+    /// @param underlyingToken the address of the token to track collateral for corresponding to the Panoptic Pool being created by the factory calling this (as 'msg.sender').
     /// @param uniswapPool the address of the Uniswap pool that this token is a part of.
     /// @param panopticPool the address of the Panoptic Pool being created and linked to this Collateral Tracker.
     function startToken(
@@ -818,7 +818,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Get the cost of exercising an option. Used during a forced exercise.
     /// @dev This one computes the cost of calling the forceExercise function on a position:
-    /// - The forceExercisor will have to *pay* the exercise because their position will be closed "against their will"
+    /// - The forceExercisor will have to *pay* the exercisee because their position will be closed "against their will"
     /// - The cost must be larger when the position is close to being in-range, and should be minimal when it is far from being in range. eg. Exercising a (1000, 1050)
     ///   position will cost more if the price is 999 than if it is 100
     /// - The cost is an exponentially decaying function of the distance between the position's strike and the current price
@@ -850,7 +850,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint160 currentSqrtPriceX96 = TickMath.getSqrtRatioAtTick(currentTick);
         uint160 medianSqrtPriceX96 = TickMath.getSqrtRatioAtTick(medianTick);
         unchecked {
-            for (uint256 leg; leg < TokenId.countLegs(positionId); ++leg) {
+            for (uint256 leg = 0; leg < TokenId.countLegs(positionId); ++leg) {
                 // short legs are not counted - exercise is intended to be based on long legs
                 if (positionId.isLong(leg) == 0) continue;
 
@@ -945,7 +945,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Returns the original delegated value to a user at a certain tick based on the available collateral from the exercised user.
     /// @dev Only called on collateralTracker0, so we must query balances from collateralTracker1.
-    /// @param refunder Address of the user the refund is coming from (the force exercise).
+    /// @param refunder Address of the user the refund is coming from (the force exercisee).
     /// @param refundValues Token values to refund at the given tick(atTick) rightSlot = token0 left = token1.
     /// @param atTick Tick to convert values at. This can be the current tick or some TWAP/median tick.
     /// @param collateralToken1 The address of the collateralTracker for token 1.
@@ -1495,7 +1495,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         // Offset determined whether to consider the last tokenId from the list
         // (a potentially newly minted position)
         uint256 totalIterations = positionBalanceArray.length;
-        for (uint256 i; i < totalIterations; ) {
+        for (uint256 i = 0; i < totalIterations; ) {
             // read the ith tokenId from the account
             uint256 tokenId = positionBalanceArray[i][0];
 
@@ -1542,7 +1542,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 numLegs = tokenId.countLegs();
 
         unchecked {
-            for (uint256 index; index < numLegs; ++index) {
+            for (uint256 index = 0; index < numLegs; ++index) {
                 // revert if the tokenType does not match the current collateral token
                 if (tokenId.tokenType(index) != (underlyingIsToken0 ? 0 : 1)) continue;
                 // Increment the tokenRequired accumulator


### PR DESCRIPTION
Three types of changes made:

**1. Correct and Optimized packing of storage variables**: This is well explained here -> https://github.com/allo-protocol/allo-v2/pull/237

**2. Wastage of Gas in Initialization**: Usually all unsigned integers have a default value of 0, that means if I included this code line -> `uint256 num;`, this initialized num with 0. Thus, changes in code are made from `uint256 leg = 0;` to `uint256 leg;`

**3. Some Grammatical and Typo fixes**