### PR TITLE
feat: pyth to v3 oracle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "lib/chainlink"]
 	path = lib/chainlink
 	url = https://github.com/smartcontractkit/chainlink
+[submodule "lib/pyth-sdk-solidity"]
+	path = lib/pyth-sdk-solidity
+	url = https://github.com/pyth-network/pyth-sdk-solidity

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "lib/clones-with-immutable-args"]
 	path = lib/clones-with-immutable-args
 	url = https://github.com/wighawag/clones-with-immutable-args
+[submodule "lib/chainlink"]
+	path = lib/chainlink
+	url = https://github.com/smartcontractkit/chainlink

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -43,6 +43,7 @@ contract ChainLinkToV3Oracle {
         )
     {
         tick = chainlinkPriceToTick(getChainlinkPrice());
+        sqrtPriceX96 = TickMath.getSqrtRatioAtTick(tick);
 
         // TODO: what to return for these? need to look at how they're consumed in panoptic
         observationIndex = uint16(block.timestamp % 65536); // Cycling index based on time

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -77,7 +77,9 @@ contract ChainLinkToV3Oracle {
     {
         // Use a blockTimestamp close to now, but unique per-observation
         blockTimestamp = uint32(block.timestamp - index);
-        tickCumulative = int56(TickMath.getTickAtSqrtRatio(chainlinkPriceToSqrtRatioX96(getChainlinkPrice()))) * int56(int32(blockTimestamp));
+        tickCumulative =
+            int56(TickMath.getTickAtSqrtRatio(chainlinkPriceToSqrtRatioX96(getChainlinkPrice()))) *
+            int56(int32(blockTimestamp));
 
         // Always 0 in v4
         secondsPerLiquidityCumulativeX128 = 0;
@@ -109,7 +111,9 @@ contract ChainLinkToV3Oracle {
             // Use the same current tick for all observations
             // The cumulative = tick * timestamp at that point in time
             // This ensures TWAP calculations will always result in the current tick
-            tickCumulatives[i] = int56(currentTick) * int56(int256(block.timestamp - secondsAgos[i]));
+            tickCumulatives[i] =
+                int56(currentTick) *
+                int56(int256(block.timestamp - secondsAgos[i]));
         }
 
         // DEV: *If we wanted* we could actually get historical price at each secondsAgo -

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -103,7 +103,9 @@ contract ChainLinkToV3Oracle {
     {
         tickCumulatives = new int56[](secondsAgos.length);
 
-        int24 currentTick = TickMath.getTickAtSqrtRatio(chainlinkPriceToSqrtRatioX96(getChainlinkPrice()));
+        int24 currentTick = TickMath.getTickAtSqrtRatio(
+            chainlinkPriceToSqrtRatioX96(getChainlinkPrice())
+        );
 
         for (uint256 i = 0; i < secondsAgos.length; i++) {
             // Use the same current tick for all observations

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -7,10 +7,13 @@ import {TickMath} from "v3-core/libraries/TickMath.sol";
 
 /// @title ChainLinkToV3Oracle
 /// @notice Contract that provides a Uniswap V3-compatible oracle interface on ChainLink-sourced data.
-/// @dev We still use the v4 pool's slot0.
 contract ChainLinkToV3Oracle {
     /// @notice The ChainLink price aggregator contract this adapter interacts with.
     AggregatorV3Interface public immutable aggregator;
+
+    // TODO: _Should_ be able to pull from aggregator, but .decimals() was reverting in test
+    // Hard-coding the ETH/USD value for now, and could possibly kick this to constructor:
+    uint8 public constant DECIMALS = 8;
 
     /// @notice Initializes the adapter with the BaseOracleHook contract and pool ID.
     /// @param _aggregator The ChainLink price aggregator contract to read from
@@ -38,21 +41,17 @@ contract ChainLinkToV3Oracle {
         bool unlocked
       )
     {
-      // 1) Chainlink gives price as answer/10**decimals, e.g. ETH/USD = 3000e8
       (, int256 answer,,,) = aggregator.latestRoundData();
       require(answer > 0, "bad price");
 
-      // 2) normalize into Q64.96 sqrtPrice
-      //    price is token1/token0, so sqrtPriceX96 = sqrt(price) * 2**96
       uint256 uAnswer = uint256(answer);
-      // shift to Q128 (i.e. price * 2**128) so we can sqrt safely:
-      uint256 priceQ128 = uAnswer << 128 / (10 ** aggregator.decimals());
-      sqrtPriceX96 = uint160(sqrt(priceQ128)); // internal sqrt of uint256 → uint128
+      uint256 priceQ128 = (uAnswer << 128) / (10 ** DECIMALS);
+      uint128 rootQ64 = sqrt(priceQ128);
+      sqrtPriceX96 = uint160(uint256(rootQ64) << 32);
 
-      // 3) derive tick via Uniswap’s library
       tick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
 
-      // TODO: Decide what to return here - they don't mean much in this context
+      // TODO: Decide what to return here - they don't mean much in this context, unless we actually want to stamp oracles.
       /*(observationIndex, observationCardinality, observationCardinalityNext) =
         baseOracleHook.stateById(poolId);*/
 
@@ -69,4 +68,49 @@ contract ChainLinkToV3Oracle {
             z = (x / z + z) / 2;
         }
     }
+
+    // TODO: Some of the below should be stubbed with dummy values since they don't mean anything in this context
+    // The biggest remaining decision could be whether to do actual "observations" -
+    // e.g., record the actual returned value from ChainLink on X interval
+    // Or, we could just return an array with [ChainLinkValue - HardcodedDeviance/2, ChainLinkValue + HardcodedDeviance/2, ChainLinkValue]
+    /*
+    /// @notice Returns data about a specific observation index.
+   /// @param index The element of the observations array to fetch
+   /// @return blockTimestamp The timestamp of the observation
+   /// @return tickCumulative The tick multiplied by seconds elapsed for the life of the pool as of the observation timestamp.
+   /// @return secondsPerLiquidityCumulativeX128 The seconds per in range liquidity for the life of the pool (always 0 in V4)
+   /// @return initialized Whether the observation has been initialized and the values are safe to use
+   function observations(
+       uint256 index
+   )
+       external
+       view
+       returns (
+           uint32 blockTimestamp,
+           int56 tickCumulative,
+           uint160 secondsPerLiquidityCumulativeX128,
+           bool initialized
+       )
+   { }
+
+   /// @notice Returns the cumulative tick and liquidity as of each timestamp `secondsAgo` from the current block timestamp.
+    /// @param secondsAgos From how long ago each cumulative tick and liquidity value should be returned
+    /// @return tickCumulatives Cumulative tick values as of each `secondsAgos` from the current block timestamp
+    /// @return secondsPerLiquidityCumulativeX128s Cumulative seconds per liquidity-in-range value (always empty in V4)
+    function observe(
+        uint32[] calldata secondsAgos
+    )
+        external
+        view
+        returns (
+            int56[] memory tickCumulatives,
+            uint160[] memory secondsPerLiquidityCumulativeX128s
+        )
+    { }
+
+    /// @notice Increase the maximum number of price observations that this oracle will store.
+    /// @param observationCardinalityNext The desired minimum number of observations for the oracle to store
+    function increaseObservationCardinalityNext(uint16 observationCardinalityNext) external { }
+    */
+
 }

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -43,7 +43,9 @@ contract ChainLinkToV3Oracle {
         )
     {
         tick = chainlinkPriceToTick(getChainlinkPrice());
-        sqrtPriceX96 = TickMath.getSqrtRatioAtTick(tick);
+        // DEV: Returning the exact raw ratio here, rather than the tick-snapped one - LMK if you prefer
+        // tick-snapped, like: TickMath.getSqrtRatioAtTick(tick)
+        sqrtPriceX96 = uint160((uint256(getChainlinkPrice()) << 128) / (10**DECIMALS)) << 32;
 
         // TODO: what to return for these? need to look at how they're consumed in panoptic
         observationIndex = uint16(block.timestamp % 65536); // Cycling index based on time
@@ -136,16 +138,6 @@ contract ChainLinkToV3Oracle {
             TickMath.getTickAtSqrtRatio(
                 uint160(uint256((uint256(currentPrice) << 128) / (10 ** DECIMALS))) << 32
             );
-    }
-
-    // TODO: Replace with a standard lib
-    function sqrt(uint256 x) internal pure returns (uint128 y) {
-        uint256 z = (x + 1) / 2;
-        y = uint128(x);
-        while (z < y) {
-            y = uint128(z);
-            z = (x / z + z) / 2;
-        }
     }
 
     /// @notice This method is typically used to increase the maximum number of price observations, but we just no-op.

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -75,11 +75,9 @@ contract ChainLinkToV3Oracle {
             bool initialized
         )
     {
-        int24 tick = TickMath.getTickAtSqrtRatio(chainlinkPriceToSqrtRatioX96(getChainlinkPrice()));
-
         // Use a blockTimestamp close to now, but unique per-observation
         blockTimestamp = uint32(block.timestamp - index);
-        tickCumulative = int56(tick) * int56(int32(blockTimestamp));
+        tickCumulative = int56(TickMath.getTickAtSqrtRatio(chainlinkPriceToSqrtRatioX96(getChainlinkPrice()))) * int56(int32(blockTimestamp));
 
         // Always 0 in v4
         secondsPerLiquidityCumulativeX128 = 0;
@@ -111,8 +109,7 @@ contract ChainLinkToV3Oracle {
             // Use the same current tick for all observations
             // The cumulative = tick * timestamp at that point in time
             // This ensures TWAP calculations will always result in the current tick
-            uint256 timestamp = block.timestamp - secondsAgos[i];
-            tickCumulatives[i] = int56(currentTick) * int56(int256(timestamp));
+            tickCumulatives[i] = int56(currentTick) * int56(int256(block.timestamp - secondsAgos[i]));
         }
 
         // DEV: *If we wanted* we could actually get historical price at each secondsAgo -
@@ -135,12 +132,9 @@ contract ChainLinkToV3Oracle {
     /// @param price raw ChainLink answer (has DECIMALS decimals)
     /// @return sqrtPriceX96 = sqrt(price/10^DECIMALS) * 2^96
     function chainlinkPriceToSqrtRatioX96(int256 price) internal pure returns (uint160) {
-        uint256 p = uint256(price);
         // sqrt(p) has price’s decimals baked in; since price has 8 decimals,
         // we divide out √(10^8) = 10^4 after shifting.
-        uint256 root = sqrt(p);
-        uint256 scaled = (root << 96) / (10 ** (DECIMALS / 2));
-        return uint160(scaled);
+        return uint160((sqrt(uint256(price)) << 96) / (10 ** (DECIMALS / 2)));
     }
 
     // TODO: Replace with standard lib

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -75,9 +75,9 @@ contract ChainLinkToV3Oracle {
     {
         int24 tick = chainlinkPriceToTick(getChainlinkPrice());
 
-        // Return a blockTimestamp close to now, but unique per-observation
+        // Use a blockTimestamp close to now, but unique per-observation
         blockTimestamp = uint32(block.timestamp - index);
-        tickCumulative = int56(tick) * int56(blockTimestamp);
+        tickCumulative = int56(tick) * int56(int32(blockTimestamp));
 
         // Always 0 in v4
         secondsPerLiquidityCumulativeX128 = 0;
@@ -108,7 +108,7 @@ contract ChainLinkToV3Oracle {
             // The cumulative = tick * timestamp at that point in time
             // This ensures TWAP calculations will always result in the current tick
             uint256 timestamp = block.timestamp - secondsAgos[i];
-            tickCumulatives[i] = int56(currentTick) * int56(timestamp);
+            tickCumulatives[i] = int56(currentTick) * int56(int256(timestamp));
         }
 
         // DEV: *If we wanted* we could actually get historical price at each secondsAgo -
@@ -129,7 +129,7 @@ contract ChainLinkToV3Oracle {
 
     /// @notice Convert a ChainLink price to a Uniswap tick.
     /// @param currentPrice Price returned from ChainLink
-    /// @returns The same value, converted to a tick.
+    /// @return The same value, converted to a tick.
     function chainlinkPriceToTick(int256 currentPrice) internal pure returns (int24) {
         return
             TickMath.getTickAtSqrtRatio(

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -19,7 +19,6 @@ contract ChainLinkToV3Oracle {
     /// @param _aggregator The ChainLink price aggregator contract to read from
     constructor(AggregatorV3Interface _aggregator) {
         aggregator = _aggregator;
-        deploymentTimestamp = block.timestamp;
     }
 
     /// @notice Emulates the behavior of the exposed zeroth slot of a Uniswap V3 pool.
@@ -43,7 +42,7 @@ contract ChainLinkToV3Oracle {
             bool unlocked
         )
     {
-        tick = chainlinkPriceToTick(mockHistoricalPrice(0, 0));
+        tick = chainlinkPriceToTick(getChainlinkPrice());
 
         // TODO: what to return for these? need to look at how they're consumed in panoptic
         observationIndex = uint16(block.timestamp % 65536); // Cycling index based on time
@@ -74,7 +73,7 @@ contract ChainLinkToV3Oracle {
             bool initialized
         )
     {
-        int24 tick = chainlinkPriceToTick(mockHistoricalPrice(0, 0));
+        int24 tick = chainlinkPriceToTick(getChainlinkPrice());
 
         // Return a blockTimestamp close to now, but unique per-observation
         blockTimestamp = uint32(block.timestamp - index);
@@ -102,7 +101,7 @@ contract ChainLinkToV3Oracle {
     {
         tickCumulatives = new int56[](secondsAgos.length);
 
-        int24 currentTick = chainlinkPriceToTick(mockHistoricalPrice(0, 0));
+        int24 currentTick = chainlinkPriceToTick(getChainlinkPrice());
 
         for (uint256 i = 0; i < secondsAgos.length; i++) {
             // Use the same current tick for all observations

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+
+import {TickMath} from "v3-core/libraries/TickMath.sol";
+
+/// @title ChainLinkToV3Oracle
+/// @notice Contract that provides a Uniswap V3-compatible oracle interface on ChainLink-sourced data.
+/// @dev We still use the v4 pool's slot0.
+contract ChainLinkToV3Oracle {
+    /// @notice The ChainLink price aggregator contract this adapter interacts with.
+    AggregatorV3Interface public immutable aggregator;
+
+    /// @notice Initializes the adapter with the BaseOracleHook contract and pool ID.
+    /// @param _aggregator The ChainLink price aggregator contract to read from
+    constructor(AggregatorV3Interface _aggregator) {
+        aggregator = _aggregator;
+    }
+
+    /// @notice Emulates the behavior of the exposed zeroth slot of a Uniswap V3 pool.
+    /// @return sqrtPriceX96 The current price of the oracle as a sqrt(currency1/currency0) Q64.96 value
+    /// @return tick The current tick of the oracle
+    /// @return observationIndex The index of the last oracle observation that was written
+    /// @return observationCardinality The current maximum number of observations stored in the oracle
+    /// @return observationCardinalityNext The next maximum number of observations that can be stored in the oracle
+    /// @return feeProtocol The protocol fee for this pool (not used in V4, always 0)
+    /// @return unlocked Whether the pool is currently unlocked (always true for V4)
+    function slot0()
+      external view
+      returns (
+        uint160 sqrtPriceX96,
+        int24 tick,
+        uint16 observationIndex,
+        uint16 observationCardinality,
+        uint16 observationCardinalityNext,
+        uint8 feeProtocol,
+        bool unlocked
+      )
+    {
+      // 1) Chainlink gives price as answer/10**decimals, e.g. ETH/USD = 3000e8
+      (, int256 answer,,,) = aggregator.latestRoundData();
+      require(answer > 0, "bad price");
+
+      // 2) normalize into Q64.96 sqrtPrice
+      //    price is token1/token0, so sqrtPriceX96 = sqrt(price) * 2**96
+      uint256 uAnswer = uint256(answer);
+      // shift to Q128 (i.e. price * 2**128) so we can sqrt safely:
+      uint256 priceQ128 = uAnswer << 128 / (10 ** aggregator.decimals());
+      sqrtPriceX96 = uint160(sqrt(priceQ128)); // internal sqrt of uint256 → uint128
+
+      // 3) derive tick via Uniswap’s library
+      tick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
+
+      // TODO: Decide what to return here - they don't mean much in this context
+      /*(observationIndex, observationCardinality, observationCardinalityNext) =
+        baseOracleHook.stateById(poolId);*/
+
+      feeProtocol = 0;
+      unlocked = true;
+    }
+
+    // TODO: Replace with a standard lib
+    function sqrt(uint256 x) internal pure returns (uint128 y) {
+        uint256 z = (x + 1) / 2;
+        y = uint128(x);
+        while (z < y) {
+            y = uint128(z);
+            z = (x / z + z) / 2;
+        }
+    }
+}

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -42,10 +42,8 @@ contract ChainLinkToV3Oracle {
             bool unlocked
         )
     {
-        tick = chainlinkPriceToTick(getChainlinkPrice());
-        // DEV: Returning the exact raw ratio here, rather than the tick-snapped one - LMK if you prefer
-        // tick-snapped, like: TickMath.getSqrtRatioAtTick(tick)
-        sqrtPriceX96 = uint160((uint256(getChainlinkPrice()) << 128) / (10**DECIMALS)) << 32;
+        sqrtPriceX96 = chainlinkPriceToSqrtRatioX96(getChainlinkPrice());
+        tick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
 
         // TODO: what to return for these? need to look at how they're consumed in panoptic
         observationIndex = uint16(block.timestamp % 65536); // Cycling index based on time
@@ -76,7 +74,7 @@ contract ChainLinkToV3Oracle {
             bool initialized
         )
     {
-        int24 tick = chainlinkPriceToTick(getChainlinkPrice());
+        int24 tick = TickMath.getTickAtSqrtRatio(chainlinkPriceToSqrtRatioX96(getChainlinkPrice()));
 
         // Use a blockTimestamp close to now, but unique per-observation
         blockTimestamp = uint32(block.timestamp - index);
@@ -104,7 +102,7 @@ contract ChainLinkToV3Oracle {
     {
         tickCumulatives = new int56[](secondsAgos.length);
 
-        int24 currentTick = chainlinkPriceToTick(getChainlinkPrice());
+        int24 currentTick = TickMath.getTickAtSqrtRatio(chainlinkPriceToSqrtRatioX96(getChainlinkPrice()));
 
         for (uint256 i = 0; i < secondsAgos.length; i++) {
             // Use the same current tick for all observations
@@ -130,14 +128,28 @@ contract ChainLinkToV3Oracle {
         return currentPrice;
     }
 
-    /// @notice Convert a ChainLink price to a Uniswap tick.
-    /// @param currentPrice Price returned from ChainLink
-    /// @return The same value, converted to a tick.
-    function chainlinkPriceToTick(int256 currentPrice) internal pure returns (int24) {
-        return
-            TickMath.getTickAtSqrtRatio(
-                uint160(uint256((uint256(currentPrice) << 128) / (10 ** DECIMALS))) << 32
-            );
+    /// @notice Take the square root of a ChainLink price and put it into X96 format.
+    /// @param price raw ChainLink answer (has DECIMALS decimals)
+    /// @return sqrtPriceX96 = sqrt(price/10^DECIMALS) * 2^96
+    function chainlinkPriceToSqrtRatioX96(int256 price) internal pure returns (uint160) {
+        uint256 p = uint256(price);
+        // sqrt(p) has price’s decimals baked in; since price has 8 decimals,
+        // we divide out √(10^8) = 10^4 after shifting.
+        uint256 root = sqrt(p);
+        uint256 scaled = (root << 96) / (10 ** (DECIMALS / 2));
+        return uint160(scaled);
+    }
+
+    // TODO: Replace with standard lib
+    function sqrt(uint256 x) internal pure returns (uint256) {
+        if (x == 0) return 0;
+        uint256 z = (x + 1) / 2;
+        uint256 y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
+        return y;
     }
 
     /// @notice This method is typically used to increase the maximum number of price observations, but we just no-op.

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -47,9 +47,7 @@ contract ChainLinkToV3Oracle {
 
         uint256 uAnswer = uint256(answer);
         uint256 priceQ128 = (uAnswer << 128) / (10 ** DECIMALS);
-        uint128 rootQ64 = sqrt(priceQ128);
-        sqrtPriceX96 = uint160(uint256(rootQ64) << 32);
-
+        sqrtPriceX96 = uint160(uint256(priceQ128)) << 32;
         tick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
 
         // TODO: Decide what to return here - they don't mean much in this context, unless we actually want to stamp oracles.

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -46,6 +46,7 @@ contract ChainLinkToV3Oracle {
         tick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
 
         // TODO: what to return for these? need to look at how they're consumed in panoptic
+        // Maybe always return cardinality >= 100? Isn't that a constraint for pool readiness somewhere?
         observationIndex = uint16(block.timestamp % 65536); // Cycling index based on time
         observationCardinality = 8; // Match the 8-slot median queue
         observationCardinalityNext = 8;

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -63,16 +63,16 @@ contract ChainLinkToV3Oracle {
     /// @return secondsPerLiquidityCumulativeX128 The seconds per in range liquidity for the life of the pool (always 0 in V4)
     /// @return initialized Whether the observation has been initialized and the values are safe to use
     function observations(
-       uint256 index
+        uint256 index
     )
-       external
-       view
-       returns (
-           uint32 blockTimestamp,
-           int56 tickCumulative,
-           uint160 secondsPerLiquidityCumulativeX128,
-           bool initialized
-       )
+        external
+        view
+        returns (
+            uint32 blockTimestamp,
+            int56 tickCumulative,
+            uint160 secondsPerLiquidityCumulativeX128,
+            bool initialized
+        )
     {
         int24 tick = chainlinkPriceToTick(mockHistoricalPrice(0, 0));
 
@@ -123,7 +123,7 @@ contract ChainLinkToV3Oracle {
     /// @notice Get the current price from ChainLink with adjustable variation.
     /// @return The current price from the aggregator
     function getChainlinkPrice() internal view returns (int256) {
-        (, int256 currentPrice,,,) = aggregator.latestRoundData();
+        (, int256 currentPrice, , , ) = aggregator.latestRoundData();
 
         return currentPrice;
     }
@@ -132,9 +132,10 @@ contract ChainLinkToV3Oracle {
     /// @param currentPrice Price returned from ChainLink
     /// @returns The same value, converted to a tick.
     function chainlinkPriceToTick(int256 currentPrice) internal pure returns (int24) {
-        return TickMath.getTickAtSqrtRatio(
-            uint160(uint256((uint256(currentPrice) << 128) / (10 ** DECIMALS))) << 32
-        );
+        return
+            TickMath.getTickAtSqrtRatio(
+                uint160(uint256((uint256(currentPrice) << 128) / (10 ** DECIMALS))) << 32
+            );
     }
 
     // TODO: Replace with a standard lib
@@ -150,5 +151,5 @@ contract ChainLinkToV3Oracle {
     /// @notice This method is typically used to increase the maximum number of price observations, but we just no-op.
     /// @dev PanopticFactory relies on this method, so we wanted to expose it, even if it does nothing.
     /// @param observationCardinalityNext The desired minimum number of observations for the oracle to store
-    function increaseObservationCardinalityNext(uint16 observationCardinalityNext) external { }
+    function increaseObservationCardinalityNext(uint16 observationCardinalityNext) external {}
 }

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -30,33 +30,34 @@ contract ChainLinkToV3Oracle {
     /// @return feeProtocol The protocol fee for this pool (not used in V4, always 0)
     /// @return unlocked Whether the pool is currently unlocked (always true for V4)
     function slot0()
-      external view
-      returns (
-        uint160 sqrtPriceX96,
-        int24 tick,
-        uint16 observationIndex,
-        uint16 observationCardinality,
-        uint16 observationCardinalityNext,
-        uint8 feeProtocol,
-        bool unlocked
-      )
+        external
+        view
+        returns (
+            uint160 sqrtPriceX96,
+            int24 tick,
+            uint16 observationIndex,
+            uint16 observationCardinality,
+            uint16 observationCardinalityNext,
+            uint8 feeProtocol,
+            bool unlocked
+        )
     {
-      (, int256 answer,,,) = aggregator.latestRoundData();
-      require(answer > 0, "bad price");
+        (, int256 answer, , , ) = aggregator.latestRoundData();
+        require(answer > 0, "bad price");
 
-      uint256 uAnswer = uint256(answer);
-      uint256 priceQ128 = (uAnswer << 128) / (10 ** DECIMALS);
-      uint128 rootQ64 = sqrt(priceQ128);
-      sqrtPriceX96 = uint160(uint256(rootQ64) << 32);
+        uint256 uAnswer = uint256(answer);
+        uint256 priceQ128 = (uAnswer << 128) / (10 ** DECIMALS);
+        uint128 rootQ64 = sqrt(priceQ128);
+        sqrtPriceX96 = uint160(uint256(rootQ64) << 32);
 
-      tick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
+        tick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
 
-      // TODO: Decide what to return here - they don't mean much in this context, unless we actually want to stamp oracles.
-      /*(observationIndex, observationCardinality, observationCardinalityNext) =
+        // TODO: Decide what to return here - they don't mean much in this context, unless we actually want to stamp oracles.
+        /*(observationIndex, observationCardinality, observationCardinalityNext) =
         baseOracleHook.stateById(poolId);*/
 
-      feeProtocol = 0;
-      unlocked = true;
+        feeProtocol = 0;
+        unlocked = true;
     }
 
     // TODO: Replace with a standard lib
@@ -112,5 +113,4 @@ contract ChainLinkToV3Oracle {
     /// @param observationCardinalityNext The desired minimum number of observations for the oracle to store
     function increaseObservationCardinalityNext(uint16 observationCardinalityNext) external { }
     */
-
 }

--- a/contracts/ChainLinkToV3Oracle.sol
+++ b/contracts/ChainLinkToV3Oracle.sol
@@ -19,6 +19,7 @@ contract ChainLinkToV3Oracle {
     /// @param _aggregator The ChainLink price aggregator contract to read from
     constructor(AggregatorV3Interface _aggregator) {
         aggregator = _aggregator;
+        deploymentTimestamp = block.timestamp;
     }
 
     /// @notice Emulates the behavior of the exposed zeroth slot of a Uniswap V3 pool.
@@ -42,46 +43,28 @@ contract ChainLinkToV3Oracle {
             bool unlocked
         )
     {
-        (, int256 answer, , , ) = aggregator.latestRoundData();
-        require(answer > 0, "bad price");
+        tick = chainlinkPriceToTick(mockHistoricalPrice(0, 0));
 
-        uint256 uAnswer = uint256(answer);
-        uint256 priceQ128 = (uAnswer << 128) / (10 ** DECIMALS);
-        sqrtPriceX96 = uint160(uint256(priceQ128)) << 32;
-        tick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
+        // TODO: what to return for these? need to look at how they're consumed in panoptic
+        observationIndex = uint16(block.timestamp % 65536); // Cycling index based on time
+        observationCardinality = 8; // Match the 8-slot median queue
+        observationCardinalityNext = 8;
 
-        // TODO: Decide what to return here - they don't mean much in this context, unless we actually want to stamp oracles.
-        /*(observationIndex, observationCardinality, observationCardinalityNext) =
-        baseOracleHook.stateById(poolId);*/
-
+        // not used in v4, so always 0
         feeProtocol = 0;
+        // always true in v4
         unlocked = true;
     }
 
-    // TODO: Replace with a standard lib
-    function sqrt(uint256 x) internal pure returns (uint128 y) {
-        uint256 z = (x + 1) / 2;
-        y = uint128(x);
-        while (z < y) {
-            y = uint128(z);
-            z = (x / z + z) / 2;
-        }
-    }
-
-    // TODO: Some of the below should be stubbed with dummy values since they don't mean anything in this context
-    // The biggest remaining decision could be whether to do actual "observations" -
-    // e.g., record the actual returned value from ChainLink on X interval
-    // Or, we could just return an array with [ChainLinkValue - HardcodedDeviance/2, ChainLinkValue + HardcodedDeviance/2, ChainLinkValue]
-    /*
     /// @notice Returns data about a specific observation index.
-   /// @param index The element of the observations array to fetch
-   /// @return blockTimestamp The timestamp of the observation
-   /// @return tickCumulative The tick multiplied by seconds elapsed for the life of the pool as of the observation timestamp.
-   /// @return secondsPerLiquidityCumulativeX128 The seconds per in range liquidity for the life of the pool (always 0 in V4)
-   /// @return initialized Whether the observation has been initialized and the values are safe to use
-   function observations(
+    /// @param index The element of the observations array to fetch
+    /// @return blockTimestamp The timestamp of the observation
+    /// @return tickCumulative The tick multiplied by seconds elapsed for the life of the pool as of the observation timestamp.
+    /// @return secondsPerLiquidityCumulativeX128 The seconds per in range liquidity for the life of the pool (always 0 in V4)
+    /// @return initialized Whether the observation has been initialized and the values are safe to use
+    function observations(
        uint256 index
-   )
+    )
        external
        view
        returns (
@@ -90,9 +73,20 @@ contract ChainLinkToV3Oracle {
            uint160 secondsPerLiquidityCumulativeX128,
            bool initialized
        )
-   { }
+    {
+        int24 tick = chainlinkPriceToTick(mockHistoricalPrice(0, 0));
 
-   /// @notice Returns the cumulative tick and liquidity as of each timestamp `secondsAgo` from the current block timestamp.
+        // Return a blockTimestamp close to now, but unique per-observation
+        blockTimestamp = uint32(block.timestamp - index);
+        tickCumulative = int56(tick) * int56(blockTimestamp);
+
+        // Always 0 in v4
+        secondsPerLiquidityCumulativeX128 = 0;
+        // These values are always safe to use - they're just stubbed based on the chainlink price
+        initialized = true;
+    }
+
+    /// @notice Returns the cumulative tick and liquidity as of each timestamp `secondsAgo` from the current block timestamp.
     /// @param secondsAgos From how long ago each cumulative tick and liquidity value should be returned
     /// @return tickCumulatives Cumulative tick values as of each `secondsAgos` from the current block timestamp
     /// @return secondsPerLiquidityCumulativeX128s Cumulative seconds per liquidity-in-range value (always empty in V4)
@@ -105,10 +99,56 @@ contract ChainLinkToV3Oracle {
             int56[] memory tickCumulatives,
             uint160[] memory secondsPerLiquidityCumulativeX128s
         )
-    { }
+    {
+        tickCumulatives = new int56[](secondsAgos.length);
 
-    /// @notice Increase the maximum number of price observations that this oracle will store.
+        int24 currentTick = chainlinkPriceToTick(mockHistoricalPrice(0, 0));
+
+        for (uint256 i = 0; i < secondsAgos.length; i++) {
+            // Use the same current tick for all observations
+            // The cumulative = tick * timestamp at that point in time
+            // This ensures TWAP calculations will always result in the current tick
+            uint256 timestamp = block.timestamp - secondsAgos[i];
+            tickCumulatives[i] = int56(currentTick) * int56(timestamp);
+        }
+
+        // DEV: *If we wanted* we could actually get historical price at each secondsAgo -
+        // but requires searching through recent `round`s on Chainlink and
+        // finding the one with a timestamp closest to the target: https://docs.chain.link/data-feeds/historical-data
+        // Instead, I just return the current price in each slot
+
+        return (tickCumulatives, new uint160[](secondsAgos.length));
+    }
+
+    /// @notice Get the current price from ChainLink with adjustable variation.
+    /// @return The current price from the aggregator
+    function getChainlinkPrice() internal view returns (int256) {
+        (, int256 currentPrice,,,) = aggregator.latestRoundData();
+
+        return currentPrice;
+    }
+
+    /// @notice Convert a ChainLink price to a Uniswap tick.
+    /// @param currentPrice Price returned from ChainLink
+    /// @returns The same value, converted to a tick.
+    function chainlinkPriceToTick(int256 currentPrice) internal pure returns (int24) {
+        return TickMath.getTickAtSqrtRatio(
+            uint160(uint256((uint256(currentPrice) << 128) / (10 ** DECIMALS))) << 32
+        );
+    }
+
+    // TODO: Replace with a standard lib
+    function sqrt(uint256 x) internal pure returns (uint128 y) {
+        uint256 z = (x + 1) / 2;
+        y = uint128(x);
+        while (z < y) {
+            y = uint128(z);
+            z = (x / z + z) / 2;
+        }
+    }
+
+    /// @notice This method is typically used to increase the maximum number of price observations, but we just no-op.
+    /// @dev PanopticFactory relies on this method, so we wanted to expose it, even if it does nothing.
     /// @param observationCardinalityNext The desired minimum number of observations for the oracle to store
     function increaseObservationCardinalityNext(uint16 observationCardinalityNext) external { }
-    */
 }

--- a/contracts/PythToV3Oracle.sol
+++ b/contracts/PythToV3Oracle.sol
@@ -1,24 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 
 import {TickMath} from "v3-core/libraries/TickMath.sol";
 
-/// @title ChainLinkToV3Oracle
-/// @notice Contract that provides a Uniswap V3-compatible oracle interface on ChainLink-sourced data.
-contract ChainLinkToV3Oracle {
-    /// @notice The ChainLink price aggregator contract this adapter interacts with.
-    AggregatorV3Interface public immutable aggregator;
+/// @title PythToV3Oracle
+/// @notice Contract that provides a Uniswap V3-compatible oracle interface on Pyth-sourced price data.
+contract PythToV3Oracle {
+    /// @notice The Pyth contract this adapter interacts with.
+    IPyth public immutable pyth;
 
-    // TODO: _Should_ be able to pull from aggregator, but .decimals() was reverting in test
-    // Hard-coding the ETH/USD value for now, and could possibly kick this to constructor:
+    /// @notice The Pyth price feed ID for the trading pair
+    bytes32 public immutable priceFeedId;
+
     uint8 public constant DECIMALS = 8;
 
-    /// @notice Initializes the adapter with the BaseOracleHook contract and pool ID.
-    /// @param _aggregator The ChainLink price aggregator contract to read from
-    constructor(AggregatorV3Interface _aggregator) {
-        aggregator = _aggregator;
+    /// @notice Initializes the adapter with the Pyth contract and price feed ID.
+    /// @param _pyth The Pyth contract to read price data from
+    /// @param _priceFeedId The Pyth price feed ID for the desired trading pair
+    constructor(IPyth _pyth, bytes32 _priceFeedId) {
+        pyth = _pyth;
+        priceFeedId = _priceFeedId;
     }
 
     /// @notice Emulates the behavior of the exposed zeroth slot of a Uniswap V3 pool.
@@ -42,7 +46,7 @@ contract ChainLinkToV3Oracle {
             bool unlocked
         )
     {
-        sqrtPriceX96 = chainlinkPriceToSqrtRatioX96(getChainlinkPrice());
+        sqrtPriceX96 = pythPriceToSqrtRatioX96(getPythPrice());
         tick = TickMath.getTickAtSqrtRatio(sqrtPriceX96);
 
         // TODO: what to return for these? need to look at how they're consumed in panoptic
@@ -78,7 +82,7 @@ contract ChainLinkToV3Oracle {
         // Use a blockTimestamp close to now, but unique per-observation
         blockTimestamp = uint32(block.timestamp - index);
         tickCumulative =
-            int56(TickMath.getTickAtSqrtRatio(chainlinkPriceToSqrtRatioX96(getChainlinkPrice()))) *
+            int56(TickMath.getTickAtSqrtRatio(pythPriceToSqrtRatioX96(getPythPrice()))) *
             int56(int32(blockTimestamp));
 
         // Always 0 in v4
@@ -104,7 +108,7 @@ contract ChainLinkToV3Oracle {
         tickCumulatives = new int56[](secondsAgos.length);
 
         int24 currentTick = TickMath.getTickAtSqrtRatio(
-            chainlinkPriceToSqrtRatioX96(getChainlinkPrice())
+            pythPriceToSqrtRatioX96(getPythPrice())
         );
 
         for (uint256 i = 0; i < secondsAgos.length; i++) {
@@ -116,36 +120,34 @@ contract ChainLinkToV3Oracle {
                 int56(int256(block.timestamp - secondsAgos[i]));
         }
 
-        // DEV: *If we wanted* we could actually get historical price at each secondsAgo -
-        // but requires searching through recent `round`s on Chainlink and
-        // finding the one with a timestamp closest to the target: https://docs.chain.link/data-feeds/historical-data
-        // Instead, I just return the current price in each slot
-
         return (tickCumulatives, new uint160[](secondsAgos.length));
     }
 
-    /// @notice Get the current price from ChainLink with adjustable variation.
-    /// @return The current price from the aggregator
-    function getChainlinkPrice() internal view returns (int256) {
-        (, int256 currentPrice, , , ) = aggregator.latestRoundData();
+    /// @notice Get the current price from Pyth with adjustable variation.
+    /// @return The current price from Pyth
+    function getPythPrice() internal view returns (int64) {
+        PythStructs.Price memory price = pyth.getPriceUnsafe(priceFeedId);
 
-        return currentPrice;
+        // TODO: Note, we get a publishTime back on the returned PythStructs.price too -
+        // we could do a stale check and revert here if we wanted.
+
+        return price.price;
     }
 
-    /// @notice Take the square root of a ChainLink price and put it into X96 format.
+    /// @notice Take the square root of a Pyth price and put it into X96 format.
     /// @param price raw ChainLink answer (has DECIMALS decimals)
     /// @return sqrtPriceX96 = sqrt(price/10^DECIMALS) * 2^96
-    function chainlinkPriceToSqrtRatioX96(int256 price) internal pure returns (uint160) {
+    function pythPriceToSqrtRatioX96(int64 price) internal pure returns (uint160) {
         // sqrt(p) has price’s decimals baked in; since price has 8 decimals,
         // we divide out √(10^8) = 10^4 after shifting.
-        return uint160((sqrt(uint256(price)) << 96) / (10 ** (DECIMALS / 2)));
+        return uint160((sqrt(uint64(price)) << 96) / (10 ** (DECIMALS / 2)));
     }
 
     // TODO: Replace with standard lib
-    function sqrt(uint256 x) internal pure returns (uint256) {
-        if (x == 0) return 0;
-        uint256 z = (x + 1) / 2;
-        uint256 y = x;
+    function sqrt(uint64 x) internal pure returns (uint256) {
+        if (x == 0) return x;
+        uint64 z = (x + 1) / 2;
+        uint64 y = x;
         while (z < y) {
             y = z;
             z = (x / z + z) / 2;

--- a/contracts/PythToV3Oracle.sol
+++ b/contracts/PythToV3Oracle.sol
@@ -107,9 +107,7 @@ contract PythToV3Oracle {
     {
         tickCumulatives = new int56[](secondsAgos.length);
 
-        int24 currentTick = TickMath.getTickAtSqrtRatio(
-            pythPriceToSqrtRatioX96(getPythPrice())
-        );
+        int24 currentTick = TickMath.getTickAtSqrtRatio(pythPriceToSqrtRatioX96(getPythPrice()));
 
         for (uint256 i = 0; i < secondsAgos.length; i++) {
             // Use the same current tick for all observations

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptic-v1-core",
-  "lockfileVersion": 3,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
@@ -2089,6 +2089,1307 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    }
+  },
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.22.10",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.22.10",
+        "chalk": "^2.4.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.22.5",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.22.10",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.22.5",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@commitlint/cli": {
+      "version": "17.7.1",
+      "dev": true,
+      "requires": {
+        "@commitlint/format": "^17.4.4",
+        "@commitlint/lint": "^17.7.0",
+        "@commitlint/load": "^17.7.1",
+        "@commitlint/read": "^17.5.1",
+        "@commitlint/types": "^17.4.4",
+        "execa": "^5.0.0",
+        "lodash.isfunction": "^3.0.9",
+        "resolve-from": "5.0.0",
+        "resolve-global": "1.0.0",
+        "yargs": "^17.0.0"
+      }
+    },
+    "@commitlint/config-conventional": {
+      "version": "17.7.0",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-conventionalcommits": "^6.1.0"
+      }
+    },
+    "@commitlint/config-validator": {
+      "version": "17.6.7",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^17.4.4",
+        "ajv": "^8.11.0"
+      }
+    },
+    "@commitlint/ensure": {
+      "version": "17.6.7",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^17.4.4",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
+      }
+    },
+    "@commitlint/execute-rule": {
+      "version": "17.4.0",
+      "dev": true
+    },
+    "@commitlint/format": {
+      "version": "17.4.4",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^17.4.4",
+        "chalk": "^4.1.0"
+      }
+    },
+    "@commitlint/is-ignored": {
+      "version": "17.7.0",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^17.4.4",
+        "semver": "7.5.4"
+      }
+    },
+    "@commitlint/lint": {
+      "version": "17.7.0",
+      "dev": true,
+      "requires": {
+        "@commitlint/is-ignored": "^17.7.0",
+        "@commitlint/parse": "^17.7.0",
+        "@commitlint/rules": "^17.7.0",
+        "@commitlint/types": "^17.4.4"
+      }
+    },
+    "@commitlint/load": {
+      "version": "17.7.1",
+      "dev": true,
+      "requires": {
+        "@commitlint/config-validator": "^17.6.7",
+        "@commitlint/execute-rule": "^17.4.0",
+        "@commitlint/resolve-extends": "^17.6.7",
+        "@commitlint/types": "^17.4.4",
+        "@types/node": "20.4.7",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^8.0.0",
+        "cosmiconfig-typescript-loader": "^4.0.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0",
+        "resolve-from": "^5.0.0",
+        "ts-node": "^10.8.1",
+        "typescript": "^4.6.4 || ^5.0.0"
+      }
+    },
+    "@commitlint/message": {
+      "version": "17.4.2",
+      "dev": true
+    },
+    "@commitlint/parse": {
+      "version": "17.7.0",
+      "dev": true,
+      "requires": {
+        "@commitlint/types": "^17.4.4",
+        "conventional-changelog-angular": "^6.0.0",
+        "conventional-commits-parser": "^4.0.0"
+      }
+    },
+    "@commitlint/read": {
+      "version": "17.5.1",
+      "dev": true,
+      "requires": {
+        "@commitlint/top-level": "^17.4.0",
+        "@commitlint/types": "^17.4.4",
+        "fs-extra": "^11.0.0",
+        "git-raw-commits": "^2.0.11",
+        "minimist": "^1.2.6"
+      }
+    },
+    "@commitlint/resolve-extends": {
+      "version": "17.6.7",
+      "dev": true,
+      "requires": {
+        "@commitlint/config-validator": "^17.6.7",
+        "@commitlint/types": "^17.4.4",
+        "import-fresh": "^3.0.0",
+        "lodash.mergewith": "^4.6.2",
+        "resolve-from": "^5.0.0",
+        "resolve-global": "^1.0.0"
+      }
+    },
+    "@commitlint/rules": {
+      "version": "17.7.0",
+      "dev": true,
+      "requires": {
+        "@commitlint/ensure": "^17.6.7",
+        "@commitlint/message": "^17.4.2",
+        "@commitlint/to-lines": "^17.4.0",
+        "@commitlint/types": "^17.4.4",
+        "execa": "^5.0.0"
+      }
+    },
+    "@commitlint/to-lines": {
+      "version": "17.4.0",
+      "dev": true
+    },
+    "@commitlint/top-level": {
+      "version": "17.4.0",
+      "dev": true,
+      "requires": {
+        "find-up": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        }
+      }
+    },
+    "@commitlint/types": {
+      "version": "17.4.4",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0"
+      }
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@solidity-parser/parser": {
+      "version": "0.16.1",
+      "dev": true,
+      "requires": {
+        "antlr4ts": "^0.5.0-alpha.4"
+      }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "dev": true
+    },
+    "@types/minimist": {
+      "version": "1.2.2",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "20.4.7",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "dev": true
+    },
+    "acorn": {
+      "version": "8.10.0",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "dev": true
+    },
+    "ajv": {
+      "version": "8.12.0",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "antlr4ts": {
+      "version": "0.5.0-alpha.4",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "dev": true
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "array-ify": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "cliui": {
+      "version": "8.0.1",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "dev": true
+    },
+    "compare-func": {
+      "version": "2.0.0",
+      "dev": true,
+      "requires": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
+    "conventional-changelog-angular": {
+      "version": "6.0.0",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0"
+      }
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "6.1.0",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0"
+      }
+    },
+    "conventional-commits-parser": {
+      "version": "4.0.0",
+      "dev": true,
+      "requires": {
+        "is-text-path": "^1.0.1",
+        "JSONStream": "^1.3.5",
+        "meow": "^8.1.2",
+        "split2": "^3.2.2"
+      }
+    },
+    "cosmiconfig": {
+      "version": "8.2.0",
+      "dev": true,
+      "requires": {
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0"
+      }
+    },
+    "cosmiconfig-typescript-loader": {
+      "version": "4.4.0",
+      "dev": true,
+      "requires": {}
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "dargs": {
+      "version": "7.0.0",
+      "dev": true
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.1",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "dev": true
+        }
+      }
+    },
+    "diff": {
+      "version": "4.0.2",
+      "dev": true
+    },
+    "dot-prop": {
+      "version": "5.3.0",
+      "dev": true,
+      "requires": {
+        "is-obj": "^2.0.0"
+      }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "dev": true
+    },
+    "execa": {
+      "version": "5.1.1",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "11.1.1",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "dev": true
+    },
+    "git-raw-commits": {
+      "version": "2.0.11",
+      "dev": true,
+      "requires": {
+        "dargs": "^7.0.0",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "split2": "^3.0.0",
+        "through2": "^4.0.0"
+      }
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "dev": true
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "husky": {
+      "version": "8.0.3",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "dev": true
+        }
+      }
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.8",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.13.0",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "is-text-path": {
+      "version": "1.0.1",
+      "dev": true,
+      "requires": {
+        "text-extensions": "^1.0.0"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.5",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "dev": true
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "dev": true
+    },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "dev": true
+    },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "dev": true
+    },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "dev": true
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "dev": true
+    },
+    "lodash.upperfirst": {
+      "version": "4.3.1",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "4.3.0",
+      "dev": true
+    },
+    "meow": {
+      "version": "8.1.2",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.18.1",
+          "dev": true
+        }
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "minimist": {
+      "version": "1.2.8",
+      "dev": true
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      }
+    },
+    "normalize-package-data": {
+      "version": "3.0.3",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.0.1",
+      "dev": true
+    },
+    "prettier-plugin-solidity": {
+      "version": "1.1.3",
+      "dev": true,
+      "requires": {
+        "@solidity-parser/parser": "^0.16.0",
+        "semver": "^7.3.8",
+        "solidity-comments-extractor": "^0.0.7"
+      }
+    },
+    "punycode": {
+      "version": "2.3.0",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.2",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "dev": true
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.2",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.22.4",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "5.0.0",
+      "dev": true
+    },
+    "resolve-global": {
+      "version": "1.0.0",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "dev": true
+    },
+    "semver": {
+      "version": "7.5.4",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "dev": true
+    },
+    "solidity-comments-extractor": {
+      "version": "0.0.7",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.2.0",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.13",
+      "dev": true
+    },
+    "split2": {
+      "version": "3.2.2",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "text-extensions": {
+      "version": "1.9.0",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "dev": true
+    },
+    "through2": {
+      "version": "4.0.2",
+      "dev": true,
+      "requires": {
+        "readable-stream": "3"
+      }
+    },
+    "trim-newlines": {
+      "version": "3.0.1",
+      "dev": true
+    },
+    "ts-node": {
+      "version": "10.9.1",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.6.0",
+      "dev": true
+    },
+    "typescript": {
+      "version": "5.1.6",
+      "dev": true
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "yargs": {
+      "version": "17.7.2",
+      "dev": true,
+      "requires": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "dependencies": {
+        "yargs-parser": {
+          "version": "21.1.1",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "dev": true
     }
   }
 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -14,3 +14,4 @@ v4-core/=lib/v4-core/src
 @types/=contracts/types
 @scripts/=scripts
 @uniswap/=lib
+@chainlink/contracts/=lib/chainlink/contracts/

--- a/remappings.txt
+++ b/remappings.txt
@@ -15,3 +15,4 @@ v4-core/=lib/v4-core/src
 @scripts/=scripts
 @uniswap/=lib
 @chainlink/contracts/=lib/chainlink/contracts/
+@pythnetwork/pyth-sdk-solidity/=lib/pyth-sdk-solidity/

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 import "../../../contracts/ChainLinkToV3Oracle.sol";
 import "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
 import "@uniswap/v3-core/contracts/libraries/TickMath.sol";
+import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 
 contract ChainLinkToV3OracleTest is Test {
     ChainLinkToV3Oracle oracle;
@@ -12,6 +13,7 @@ contract ChainLinkToV3OracleTest is Test {
         AggregatorV3Interface(
             0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419 // ETH/USD aggregator on mainnet
         );
+    IUniswapV3Pool ethUsdcPool = IUniswapV3Pool(0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640);
 
     function setUp() public {
         uint256 forkId = vm.createFork(vm.envString("MAINNET_RPC_URL"));
@@ -51,7 +53,7 @@ contract ChainLinkToV3OracleTest is Test {
 
     function testSlot0ConsistentWithChainlink() public {
         (, int256 chainlinkPrice, , , ) = aggregator.latestRoundData();
-        (, int24 oracleTick, , , , , ) = oracle.slot0();
+        (uint160 sqrtPriceX96, int24 oracleTick, , , , , ) = oracle.slot0();
 
         // Convert chainlink price to expected tick
         uint256 uPrice = uint256(chainlinkPrice);
@@ -60,6 +62,7 @@ contract ChainLinkToV3OracleTest is Test {
         int24 expectedTick = TickMath.getTickAtSqrtRatio(expectedSqrtPriceX96);
 
         assertEq(oracleTick, expectedTick, "Oracle tick should match chainlink-derived tick");
+        assertEq(sqrtPriceX96, expectedSqrtPriceX96, "Oracle sqrtPrice should match chainlink-derived price");
     }
 
     function testObservationsReturnsValidData() public {
@@ -88,11 +91,11 @@ contract ChainLinkToV3OracleTest is Test {
 
     function testObservationsConsistency() public {
         // Get two consecutive observations
-        (uint32 ts0, int56 cum0, , ) = oracle.observations(0);
-        (uint32 ts1, int56 cum1, , ) = oracle.observations(1);
+        (uint32 ts0, int56 cumulative0, , ) = oracle.observations(0);
+        (uint32 ts1, int56 cumulative1, , ) = oracle.observations(1);
 
         // Calculate the tick from cumulative difference
-        int24 derivedTick = int24((cum0 - cum1) / int56(uint56(ts0 - ts1)));
+        int24 derivedTick = int24((cumulative0 - cumulative1) / int56(uint56(ts0 - ts1)));
 
         // Should match current tick from slot0
         (, int24 currentTick, , , , , ) = oracle.slot0();
@@ -155,6 +158,34 @@ contract ChainLinkToV3OracleTest is Test {
         assertEq(twap, currentTick, "TWAP should equal current tick");
     }
 
+    function testFuzzObserveTWAPCalculation(uint32 secondsAgo1, uint32 secondsAgo2) public {
+        // Ensure reasonable bounds and ordering
+        vm.assume(secondsAgo1 <= 86400); // max 1 day
+        vm.assume(secondsAgo2 <= 86400);
+        vm.assume(secondsAgo1 != secondsAgo2); // must be different
+
+        // Ensure proper ordering (secondsAgo2 > secondsAgo1)
+        if (secondsAgo1 > secondsAgo2) {
+            (secondsAgo1, secondsAgo2) = (secondsAgo2, secondsAgo1);
+        }
+
+        uint32[] memory secondsAgos = new uint32[](2);
+        secondsAgos[0] = secondsAgo1;
+        secondsAgos[1] = secondsAgo2;
+
+        (int56[] memory tickCumulatives, ) = oracle.observe(secondsAgos);
+
+        // Calculate TWAP manually
+        uint32 timeDiff = secondsAgo2 - secondsAgo1;
+        int24 twap = int24((tickCumulatives[0] - tickCumulatives[1]) / int56(uint56(timeDiff)));
+
+        // Should equal current tick since we use same tick for all observations
+        (, int24 currentTick, , , , , ) = oracle.slot0();
+        assertEq(twap, currentTick, "TWAP should equal current tick for any time period");
+    }
+
+    // TODO: Also fuzz test different length arrays (e.g. anywhere from 1 to max array length secondsAgos)
+
     function testObserveEmptyArray() public {
         uint32[] memory emptyArray = new uint32[](0);
         (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = oracle.observe(
@@ -207,8 +238,32 @@ contract ChainLinkToV3OracleTest is Test {
         );
     }
 
-    // TODO: Also pull the ETH/USD price from a big mainnet pool and test that its price is within 1% of what your oracle says
+    function testPriceComparisonWithUniswapPool() public {
+        // Get price from our oracle
+        (, int24 oracleTick, , , , , ) = oracle.slot0();
+        uint160 oracleSqrtPriceX96 = TickMath.getSqrtRatioAtTick(oracleTick);
 
+        // Get price from actual Uniswap V3 ETH/USDC pool
+        (uint160 poolSqrtPriceX96, , , , , , ) = ethUsdcPool.slot0();
+
+        // Convert to human-readable prices for comparison
+        // For ETH/USD: price = (sqrtPriceX96)^2 / 2^192
+        uint256 oraclePrice = (uint256(oracleSqrtPriceX96) * uint256(oracleSqrtPriceX96)) >> 192;
+        uint256 poolPrice = (uint256(poolSqrtPriceX96) * uint256(poolSqrtPriceX96)) >> 192;
+
+        // Calculate percentage difference
+        uint256 diff = oraclePrice > poolPrice ? oraclePrice - poolPrice : poolPrice - oraclePrice;
+        uint256 percentDiff = (diff * 10000) / poolPrice; // basis points
+
+        // Prices should be within 1% (100 basis points) of each other
+        assertLe(percentDiff, 100, "Oracle price should be within 1% of Uniswap pool price");
+
+        console.log("Oracle price:", oraclePrice);
+        console.log("Pool price:", poolPrice);
+        console.log("Difference (bps):", percentDiff);
+    }
+
+    // TODO
     function testRevertOnBadChainlinkPrice() public {
         // This test would require mocking the aggregator to return bad data
         // For now, we trust that the mainnet ETH/USD feed returns valid data

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -45,11 +45,15 @@ contract ChainLinkToV3OracleTest is Test {
         // Verify tick and sqrtPrice are consistent
         uint160 sqrtPriceFromTick = TickMath.getSqrtRatioAtTick(tick);
         // (The sqrtPriceX96 is more precise than the tick, so we must allow up to 1 tick tolerance)
-        uint160 lower = uint160(FullMath.mulDiv(sqrtPriceFromTick, uint160(10_000), uint160(10_001)));
-        uint160 upper = uint160(FullMath.mulDiv(sqrtPriceFromTick, uint160(10_001), uint160(10_000)));
+        uint160 lower = uint160(
+            FullMath.mulDiv(sqrtPriceFromTick, uint160(10_000), uint160(10_001))
+        );
+        uint160 upper = uint160(
+            FullMath.mulDiv(sqrtPriceFromTick, uint160(10_001), uint160(10_000))
+        );
         assertTrue(
-          sqrtPriceX96 >= lower && sqrtPriceX96 <= upper,
-          "sqrtPrice not within one tick of TickMath roundtrip"
+            sqrtPriceX96 >= lower && sqrtPriceX96 <= upper,
+            "sqrtPrice not within one tick of TickMath roundtrip"
         );
     }
 
@@ -254,9 +258,9 @@ contract ChainLinkToV3OracleTest is Test {
         // 3) Match the decimals to chainlink's and flip token order to USD per ETH:
         //    USD/ETH = (1 / (WETH/USDC)) = 1e12 / poolRaw
         uint256 poolPrice = FullMath.mulDiv(
-            1e12,    // numerator
-            1,       // second factor
-            poolRaw  // denominator
+            1e12, // numerator
+            1, // second factor
+            poolRaw // denominator
         );
 
         uint256 diff = oraclePrice > poolPrice ? oraclePrice - poolPrice : poolPrice - oraclePrice;

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -16,7 +16,6 @@ contract ChainLinkToV3OracleTest is Test {
     function setUp() public {
         uint256 forkId = vm.createFork(vm.envString("MAINNET_RPC_URL"));
         vm.selectFork(forkId);
-
         oracle = new ChainLinkToV3Oracle(aggregator);
     }
 
@@ -31,12 +30,15 @@ contract ChainLinkToV3OracleTest is Test {
             bool unlocked
         ) = oracle.slot0();
 
-        // Basic sanity
+        // Basic sanity checks
         assertGt(uint256(sqrtPriceX96), 0, "sqrtPriceX96 should be > 0");
         assertGt(int256(tick), 0, "tick should be > 0");
         assertEq(feeProtocol, 0, "feeProtocol always 0");
         assertTrue(unlocked, "unlocked always true");
+        assertEq(obsCard, 8, "observationCardinality should be 8");
+        assertEq(obsCardNext, 8, "observationCardinalityNext should be 8");
 
+        // Verify tick and sqrtPrice are consistent
         uint160 sqrtPriceFromTick = TickMath.getSqrtRatioAtTick(tick);
         uint256 diff = sqrtPriceX96 > sqrtPriceFromTick
             ? sqrtPriceX96 - sqrtPriceFromTick
@@ -45,5 +47,164 @@ contract ChainLinkToV3OracleTest is Test {
             (diff * 1e5) / sqrtPriceFromTick <= 1 || diff <= 1,
             "sqrtPrice vs TickMath mismatch >0.1% & > 1 whole unit"
         );
+    }
+
+    function testSlot0ConsistentWithChainlink() public {
+        (, int256 chainlinkPrice, , , ) = aggregator.latestRoundData();
+        (, int24 oracleTick, , , , , ) = oracle.slot0();
+
+        // Convert chainlink price to expected tick
+        uint256 uPrice = uint256(chainlinkPrice);
+        uint256 priceQ128 = (uPrice << 128) / (10 ** 8); // DECIMALS = 8
+        uint160 expectedSqrtPriceX96 = uint160(uint256(priceQ128)) << 32;
+        int24 expectedTick = TickMath.getTickAtSqrtRatio(expectedSqrtPriceX96);
+
+        assertEq(oracleTick, expectedTick, "Oracle tick should match chainlink-derived tick");
+    }
+
+    function testObservationsReturnsValidData() public {
+        for (uint256 i = 0; i < 10; i++) {
+            (
+                uint32 blockTimestamp,
+                int56 tickCumulative,
+                uint160 secondsPerLiquidityX128,
+                bool initialized
+            ) = oracle.observations(i);
+
+            // Basic checks
+            assertTrue(initialized, "All observations should be initialized");
+            assertEq(secondsPerLiquidityX128, 0, "secondsPerLiquidity always 0 in V4");
+            assertLe(blockTimestamp, block.timestamp, "blockTimestamp shouldn't be in future");
+            assertEq(blockTimestamp, uint32(block.timestamp - i), "blockTimestamp should be now - index");
+
+            // tickCumulative should be reasonable
+            assertGt(int256(tickCumulative), 0, "tickCumulative should be positive for ETH/USD");
+        }
+    }
+
+    function testObservationsConsistency() public {
+        // Get two consecutive observations
+        (uint32 ts0, int56 cum0, , ) = oracle.observations(0);
+        (uint32 ts1, int56 cum1, , ) = oracle.observations(1);
+
+        // Calculate the tick from cumulative difference
+        int24 derivedTick = int24((cum0 - cum1) / int56(uint56(ts0 - ts1)));
+
+        // Should match current tick from slot0
+        (, int24 currentTick, , , , , ) = oracle.slot0();
+        assertEq(derivedTick, currentTick, "Derived tick from observations should match slot0 tick");
+    }
+
+    function testObserveReturnsValidData() public {
+        uint32[] memory secondsAgos = new uint32[](5);
+        secondsAgos[0] = 0;    // now
+        secondsAgos[1] = 60;   // 1 minute ago
+        secondsAgos[2] = 300;  // 5 minutes ago
+        secondsAgos[3] = 600;  // 10 minutes ago
+        secondsAgos[4] = 1800; // 30 minutes ago
+
+        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = oracle.observe(secondsAgos);
+
+        assertEq(tickCumulatives.length, secondsAgos.length, "Should return same length arrays");
+        assertEq(liquidityCumulatives.length, secondsAgos.length, "Should return same length arrays");
+
+        // All liquidity cumulatives should be 0
+        for (uint256 i = 0; i < liquidityCumulatives.length; i++) {
+            assertEq(liquidityCumulatives[i], 0, "liquidityCumulatives always 0");
+        }
+
+        // Tick cumulatives should be decreasing (older timestamps = smaller cumulatives)
+        for (uint256 i = 0; i < tickCumulatives.length - 1; i++) {
+            assertGt(tickCumulatives[i], tickCumulatives[i + 1], "Newer observations should have larger cumulatives");
+        }
+    }
+
+    function testObserveTWAPCalculation() public {
+        uint32[] memory secondsAgos = new uint32[](2);
+        secondsAgos[0] = 0;   // now
+        secondsAgos[1] = 600; // 10 minutes ago
+
+        (int56[] memory tickCumulatives, ) = oracle.observe(secondsAgos);
+
+        // Calculate TWAP manually
+        int24 twap = int24((tickCumulatives[0] - tickCumulatives[1]) / int56(600));
+
+        // Should equal current tick since we use same tick for all observations
+        (, int24 currentTick, , , , , ) = oracle.slot0();
+        assertEq(twap, currentTick, "TWAP should equal current tick");
+    }
+
+    function testObserveEmptyArray() public {
+        uint32[] memory emptyArray = new uint32[](0);
+        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = oracle.observe(emptyArray);
+
+        assertEq(tickCumulatives.length, 0, "Should return empty array");
+        assertEq(liquidityCumulatives.length, 0, "Should return empty array");
+    }
+
+    function testObserveLargeArray() public {
+        uint32[] memory largeArray = new uint32[](100);
+        for (uint256 i = 0; i < largeArray.length; i++) {
+            largeArray[i] = uint32(i * 60); // Every minute for 100 minutes
+        }
+
+        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = oracle.observe(largeArray);
+
+        assertEq(tickCumulatives.length, 100, "Should handle large arrays");
+        assertEq(liquidityCumulatives.length, 100, "Should handle large arrays");
+    }
+
+    function testIncreaseObservationCardinalityNext() public {
+        // Should not revert
+        oracle.increaseObservationCardinalityNext(16);
+        oracle.increaseObservationCardinalityNext(1);
+        oracle.increaseObservationCardinalityNext(type(uint16).max);
+
+        // Values shouldn't change since it's a no-op
+        (, , , uint16 obsCard, uint16 obsCardNext, , ) = oracle.slot0();
+        assertEq(obsCard, 8, "observationCardinality unchanged");
+        assertEq(obsCardNext, 8, "observationCardinalityNext unchanged");
+    }
+
+    function testPriceConsistencyAcrossTime() public {
+        // Record initial values
+        (, int24 initialTick, , , , , ) = oracle.slot0();
+
+        // Fast forward time
+        vm.warp(block.timestamp + 1000);
+
+        // Values should be the same (since we use current chainlink price)
+        (, int24 laterTick, , , , , ) = oracle.slot0();
+        assertEq(laterTick, initialTick, "Tick should be consistent across time (same chainlink round)");
+    }
+
+    function testChainlinkPriceToTickConversion() public {
+        // Test some known price ranges for ETH/USD
+        int256 price2000 = 2000 * 1e8; // $2000 with 8 decimals
+        int256 price4000 = 4000 * 1e8; // $4000 with 8 decimals
+
+        // These should produce valid ticks
+        uint256 price2000Q128 = (uint256(price2000) << 128) / (10 ** 8);
+        uint160 sqrt2000 = uint160(uint256(price2000Q128)) << 32;
+        int24 tick2000 = TickMath.getTickAtSqrtRatio(sqrt2000);
+
+        uint256 price4000Q128 = (uint256(price4000) << 128) / (10 ** 8);
+        uint160 sqrt4000 = uint160(uint256(price4000Q128)) << 32;
+        int24 tick4000 = TickMath.getTickAtSqrtRatio(sqrt4000);
+
+        // Higher price should give higher tick
+        assertGt(tick4000, tick2000, "Higher price should produce higher tick");
+
+        // Ticks should be within valid range
+        assertGe(tick2000, TickMath.MIN_TICK, "Tick should be >= MIN_TICK");
+        assertLe(tick2000, TickMath.MAX_TICK, "Tick should be <= MAX_TICK");
+        assertGe(tick4000, TickMath.MIN_TICK, "Tick should be >= MIN_TICK");
+        assertLe(tick4000, TickMath.MAX_TICK, "Tick should be <= MAX_TICK");
+    }
+
+    function testRevertOnBadChainlinkPrice() public {
+        // This test would require mocking the aggregator to return bad data
+        // For now, we trust that the mainnet ETH/USD feed returns valid data
+        // In a more comprehensive test suite, you'd mock this
     }
 }

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import "../../../contracts/ChainLinkToV3Oracle.sol";
+import "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+import "@uniswap/v3-core/contracts/libraries/TickMath.sol";
+
+contract ChainLinkToV3OracleTest is Test {
+    ChainLinkToV3Oracle oracle;
+    AggregatorV3Interface aggregator = AggregatorV3Interface(
+        0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419 // ETH/USD aggregator on mainnet
+    );
+
+    function setUp() public {
+        // Fork mainnet (requires MAINNET_RPC_URL env var)
+        uint256 forkId = vm.createFork(vm.envString("MAINNET_RPC_URL"));
+        vm.selectFork(forkId);
+
+        // Deploy with dummy manager and poolId
+        oracle = new ChainLinkToV3Oracle(
+            aggregator
+        );
+    }
+
+    function testSlot0ReturnsValidPrice() public {
+        (
+            uint160 sqrtPriceX96,
+            int24 tick,
+            uint16 obsIdx,
+            uint16 obsCard,
+            uint16 obsCardNext,
+            uint8 feeProtocol,
+            bool unlocked
+        ) = oracle.slot0();
+
+        // Basic sanity
+        assertGt(uint256(sqrtPriceX96), 0, "sqrtPriceX96 should be > 0");
+        assertGt(int256(tick), 0, "tick should be > 0");
+        assertEq(feeProtocol, 0, "feeProtocol always 0");
+        assertTrue(unlocked, "unlocked always true");
+
+        // Reconstruct sqrtPrice from tick and compare within 0.1%
+        uint160 fromTick = TickMath.getSqrtRatioAtTick(tick);
+        uint256 diff = sqrtPriceX96 > fromTick ? sqrtPriceX96 - fromTick : fromTick - sqrtPriceX96;
+        assertLt(diff * 1e5 / fromTick, 1, "sqrtPrice vs TickMath mismatch >0.1% ");
+    }
+}

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -36,7 +36,7 @@ contract ChainLinkToV3OracleTest is Test {
 
         // Basic sanity checks
         assertGt(uint256(sqrtPriceX96), 0, "sqrtPriceX96 should be > 0");
-        assertGt(int256(tick), 0, "tick should be > 0");
+        assertGt(int256(tick), 0, "tick should be > 0, unless ETH crashed below $1");
         assertEq(feeProtocol, 0, "feeProtocol always 0");
         assertTrue(unlocked, "unlocked always true");
         assertEq(obsCard, 8, "observationCardinality should be 8");
@@ -44,27 +44,13 @@ contract ChainLinkToV3OracleTest is Test {
 
         // Verify tick and sqrtPrice are consistent
         uint160 sqrtPriceFromTick = TickMath.getSqrtRatioAtTick(tick);
-        uint256 diff = sqrtPriceX96 > sqrtPriceFromTick
-            ? sqrtPriceX96 - sqrtPriceFromTick
-            : sqrtPriceFromTick - sqrtPriceX96;
+        // (The sqrtPriceX96 is more precise than the tick, so we must allow up to 1 tick tolerance)
+        uint160 lower = uint160(FullMath.mulDiv(sqrtPriceFromTick, uint160(10_000), uint160(10_001)));
+        uint160 upper = uint160(FullMath.mulDiv(sqrtPriceFromTick, uint160(10_001), uint160(10_000)));
         assertTrue(
-            (diff * 1e5) / sqrtPriceFromTick <= 1 || diff <= 1,
-            "sqrtPrice vs TickMath mismatch >0.1% & > 1 whole unit"
+          sqrtPriceX96 >= lower && sqrtPriceX96 <= upper,
+          "sqrtPrice not within one tick of TickMath roundtrip"
         );
-    }
-
-    function testSlot0ConsistentWithChainlink() public {
-        (, int256 chainlinkPrice, , , ) = aggregator.latestRoundData();
-        (uint160 sqrtPriceX96, int24 oracleTick, , , , , ) = oracle.slot0();
-
-        // Convert chainlink price to expected tick
-        uint256 uPrice = uint256(chainlinkPrice);
-        uint256 priceQ128 = (uPrice << 128) / (10 ** 8); // DECIMALS = 8
-        uint160 expectedSqrtPriceX96 = uint160(uint256(priceQ128)) << 32;
-        int24 expectedTick = TickMath.getTickAtSqrtRatio(expectedSqrtPriceX96);
-
-        assertEq(oracleTick, expectedTick, "Oracle tick should match chainlink-derived tick");
-        assertEq(sqrtPriceX96, expectedSqrtPriceX96, "Oracle sqrtPrice should match chainlink-derived price");
     }
 
     function testObservationsReturnsValidData() public {
@@ -210,6 +196,7 @@ contract ChainLinkToV3OracleTest is Test {
 
         assertEq(tickCumulatives.length, 100, "Should handle large arrays");
         assertEq(liquidityCumulatives.length, 100, "Should handle large arrays");
+        // TODO: also test that the tickCumulative is still current chainlink price
     }
 
     function testIncreaseObservationCardinalityNext() public {
@@ -264,7 +251,7 @@ contract ChainLinkToV3OracleTest is Test {
             uint256(poolSqrtPriceX96),
             1 << 192
         );
-        // 3) Normalize decimals _and invert_ to get USD per ETH:
+        // 3) Match the decimals to chainlink's and flip token order to USD per ETH:
         //    USD/ETH = (1 / (WETH/USDC)) = 1e12 / poolRaw
         uint256 poolPrice = FullMath.mulDiv(
             1e12,    // numerator
@@ -272,23 +259,11 @@ contract ChainLinkToV3OracleTest is Test {
             poolRaw  // denominator
         );
 
-        console2.log("oracleTick", oracleTick);
-        console2.log("oracleSqrtPriceX96", oracleSqrtPriceX96);
-        console2.log("poolSqrtPriceX96", poolSqrtPriceX96);
-        console2.log("oraclePrice", oraclePrice);
-        console2.log("poolRaw", poolRaw);
-        console2.log("poolPrice", poolPrice);
-
-        // Calculate percentage difference
         uint256 diff = oraclePrice > poolPrice ? oraclePrice - poolPrice : poolPrice - oraclePrice;
         uint256 percentDiff = (diff * 10000) / poolPrice; // basis points
 
         // Prices should be within 1% (100 basis points) of each other
         assertLe(percentDiff, 100, "Oracle price should be within 1% of Uniswap pool price");
-
-        console.log("Oracle price:", oraclePrice);
-        console.log("Pool price:", poolPrice);
-        console.log("Difference (bps):", percentDiff);
     }
 
     // TODO
@@ -296,5 +271,17 @@ contract ChainLinkToV3OracleTest is Test {
         // This test would require mocking the aggregator to return bad data
         // For now, we trust that the mainnet ETH/USD feed returns valid data
         // In a more comprehensive test suite, you'd mock this
+    }
+
+    // TODO: Replace with standard lib
+    function sqrt(uint256 x) internal pure returns (uint256) {
+        if (x == 0) return 0;
+        uint256 z = (x + 1) / 2;
+        uint256 y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
+        return y;
     }
 }

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -13,11 +13,9 @@ contract ChainLinkToV3OracleTest is Test {
     );
 
     function setUp() public {
-        // Fork mainnet (requires MAINNET_RPC_URL env var)
         uint256 forkId = vm.createFork(vm.envString("MAINNET_RPC_URL"));
         vm.selectFork(forkId);
 
-        // Deploy with dummy manager and poolId
         oracle = new ChainLinkToV3Oracle(
             aggregator
         );
@@ -40,9 +38,8 @@ contract ChainLinkToV3OracleTest is Test {
         assertEq(feeProtocol, 0, "feeProtocol always 0");
         assertTrue(unlocked, "unlocked always true");
 
-        // Reconstruct sqrtPrice from tick and compare within 0.1%
-        uint160 fromTick = TickMath.getSqrtRatioAtTick(tick);
-        uint256 diff = sqrtPriceX96 > fromTick ? sqrtPriceX96 - fromTick : fromTick - sqrtPriceX96;
-        assertLt(diff * 1e5 / fromTick, 1, "sqrtPrice vs TickMath mismatch >0.1% ");
+        uint160 sqrtPriceFromTick = TickMath.getSqrtRatioAtTick(tick);
+        uint256 diff = sqrtPriceX96 > sqrtPriceFromTick ? sqrtPriceX96 - sqrtPriceFromTick : sqrtPriceFromTick - sqrtPriceX96;
+        assertTrue(diff * 1e5 / fromTick <= 1 || diff <= 1, "sqrtPrice vs TickMath mismatch >0.1% & > 1 whole unit");
     }
 }

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -8,17 +8,16 @@ import "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 
 contract ChainLinkToV3OracleTest is Test {
     ChainLinkToV3Oracle oracle;
-    AggregatorV3Interface aggregator = AggregatorV3Interface(
-        0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419 // ETH/USD aggregator on mainnet
-    );
+    AggregatorV3Interface aggregator =
+        AggregatorV3Interface(
+            0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419 // ETH/USD aggregator on mainnet
+        );
 
     function setUp() public {
         uint256 forkId = vm.createFork(vm.envString("MAINNET_RPC_URL"));
         vm.selectFork(forkId);
 
-        oracle = new ChainLinkToV3Oracle(
-            aggregator
-        );
+        oracle = new ChainLinkToV3Oracle(aggregator);
     }
 
     function testSlot0ReturnsValidPrice() public {
@@ -39,7 +38,12 @@ contract ChainLinkToV3OracleTest is Test {
         assertTrue(unlocked, "unlocked always true");
 
         uint160 sqrtPriceFromTick = TickMath.getSqrtRatioAtTick(tick);
-        uint256 diff = sqrtPriceX96 > sqrtPriceFromTick ? sqrtPriceX96 - sqrtPriceFromTick : sqrtPriceFromTick - sqrtPriceX96;
-        assertTrue(diff * 1e5 / fromTick <= 1 || diff <= 1, "sqrtPrice vs TickMath mismatch >0.1% & > 1 whole unit");
+        uint256 diff = sqrtPriceX96 > sqrtPriceFromTick
+            ? sqrtPriceX96 - sqrtPriceFromTick
+            : sqrtPriceFromTick - sqrtPriceX96;
+        assertTrue(
+            (diff * 1e5) / fromTick <= 1 || diff <= 1,
+            "sqrtPrice vs TickMath mismatch >0.1% & > 1 whole unit"
+        );
     }
 }

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -2,10 +2,12 @@
 pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
-import "../../../contracts/ChainLinkToV3Oracle.sol";
 import "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
 import "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+import {FullMath} from "v3-core/libraries/FullMath.sol";
+
+import "../../../contracts/ChainLinkToV3Oracle.sol";
 
 contract ChainLinkToV3OracleTest is Test {
     ChainLinkToV3Oracle oracle;
@@ -248,8 +250,16 @@ contract ChainLinkToV3OracleTest is Test {
 
         // Convert to human-readable prices for comparison
         // For ETH/USD: price = (sqrtPriceX96)^2 / 2^192
-        uint256 oraclePrice = (uint256(oracleSqrtPriceX96) * uint256(oracleSqrtPriceX96)) >> 192;
-        uint256 poolPrice = (uint256(poolSqrtPriceX96) * uint256(poolSqrtPriceX96)) >> 192;
+        uint256 oraclePrice = FullMath.mulDiv(
+            uint256(oracleSqrtPriceX96),
+            uint256(oracleSqrtPriceX96),
+            1 << 192
+        );
+        uint256 poolPrice = FullMath.mulDiv(
+            uint256(poolSqrtPriceX96),
+            uint256(poolSqrtPriceX96),
+            1 << 192
+        );
 
         // Calculate percentage difference
         uint256 diff = oraclePrice > poolPrice ? oraclePrice - poolPrice : poolPrice - oraclePrice;

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -42,7 +42,7 @@ contract ChainLinkToV3OracleTest is Test {
             ? sqrtPriceX96 - sqrtPriceFromTick
             : sqrtPriceFromTick - sqrtPriceX96;
         assertTrue(
-            (diff * 1e5) / fromTick <= 1 || diff <= 1,
+            (diff * 1e5) / sqrtPriceFromTick <= 1 || diff <= 1,
             "sqrtPrice vs TickMath mismatch >0.1% & > 1 whole unit"
         );
     }

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -135,10 +135,13 @@ contract ChainLinkToV3OracleTest is Test {
                 "Newer observations should have larger cumulatives"
             );
         }
+
+        // TODO: Test that the TWAP = chainlink price
     }
 
     function testObserveTWAPCalculation() public {
         uint32[] memory secondsAgos = new uint32[](2);
+        // TODO: Fuzz this - all possible combinations of secondsAgos should still result in TWAP equaling current price.
         secondsAgos[0] = 0; // now
         secondsAgos[1] = 600; // 10 minutes ago
 
@@ -204,29 +207,7 @@ contract ChainLinkToV3OracleTest is Test {
         );
     }
 
-    function testChainlinkPriceToTickConversion() public {
-        // Test some known price ranges for ETH/USD
-        int256 price2000 = 2000 * 1e8; // $2000 with 8 decimals
-        int256 price4000 = 4000 * 1e8; // $4000 with 8 decimals
-
-        // These should produce valid ticks
-        uint256 price2000Q128 = (uint256(price2000) << 128) / (10 ** 8);
-        uint160 sqrt2000 = uint160(uint256(price2000Q128)) << 32;
-        int24 tick2000 = TickMath.getTickAtSqrtRatio(sqrt2000);
-
-        uint256 price4000Q128 = (uint256(price4000) << 128) / (10 ** 8);
-        uint160 sqrt4000 = uint160(uint256(price4000Q128)) << 32;
-        int24 tick4000 = TickMath.getTickAtSqrtRatio(sqrt4000);
-
-        // Higher price should give higher tick
-        assertGt(tick4000, tick2000, "Higher price should produce higher tick");
-
-        // Ticks should be within valid range
-        assertGe(tick2000, TickMath.MIN_TICK, "Tick should be >= MIN_TICK");
-        assertLe(tick2000, TickMath.MAX_TICK, "Tick should be <= MAX_TICK");
-        assertGe(tick4000, TickMath.MIN_TICK, "Tick should be >= MIN_TICK");
-        assertLe(tick4000, TickMath.MAX_TICK, "Tick should be <= MAX_TICK");
-    }
+    // TODO: Also pull the ETH/USD price from a big mainnet pool and test that its price is within 1% of what your oracle says
 
     function testRevertOnBadChainlinkPrice() public {
         // This test would require mocking the aggregator to return bad data

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -250,16 +250,34 @@ contract ChainLinkToV3OracleTest is Test {
 
         // Convert to human-readable prices for comparison
         // For ETH/USD: price = (sqrtPriceX96)^2 / 2^192
+        // 1) Oracle price = USD per ETH:
         uint256 oraclePrice = FullMath.mulDiv(
             uint256(oracleSqrtPriceX96),
             uint256(oracleSqrtPriceX96),
             1 << 192
         );
-        uint256 poolPrice = FullMath.mulDiv(
+        // 2) Pool raw ratio = (token1/token0)*(10^dec0/10^dec1):
+        //    token0 = USDC (6 decimals), token1 = WETH (18 decimals)
+        //    so raw = (WETH/USDC)*1e12
+        uint256 poolRaw = FullMath.mulDiv(
             uint256(poolSqrtPriceX96),
             uint256(poolSqrtPriceX96),
             1 << 192
         );
+        // 3) Normalize decimals _and invert_ to get USD per ETH:
+        //    USD/ETH = (1 / (WETH/USDC)) = 1e12 / poolRaw
+        uint256 poolPrice = FullMath.mulDiv(
+            1e12,    // numerator
+            1,       // second factor
+            poolRaw  // denominator
+        );
+
+        console2.log("oracleTick", oracleTick);
+        console2.log("oracleSqrtPriceX96", oracleSqrtPriceX96);
+        console2.log("poolSqrtPriceX96", poolSqrtPriceX96);
+        console2.log("oraclePrice", oraclePrice);
+        console2.log("poolRaw", poolRaw);
+        console2.log("poolPrice", poolPrice);
 
         // Calculate percentage difference
         uint256 diff = oraclePrice > poolPrice ? oraclePrice - poolPrice : poolPrice - oraclePrice;

--- a/test/foundry/core/ChainLinkToV3Oracle.t.sol
+++ b/test/foundry/core/ChainLinkToV3Oracle.t.sol
@@ -75,7 +75,11 @@ contract ChainLinkToV3OracleTest is Test {
             assertTrue(initialized, "All observations should be initialized");
             assertEq(secondsPerLiquidityX128, 0, "secondsPerLiquidity always 0 in V4");
             assertLe(blockTimestamp, block.timestamp, "blockTimestamp shouldn't be in future");
-            assertEq(blockTimestamp, uint32(block.timestamp - i), "blockTimestamp should be now - index");
+            assertEq(
+                blockTimestamp,
+                uint32(block.timestamp - i),
+                "blockTimestamp should be now - index"
+            );
 
             // tickCumulative should be reasonable
             assertGt(int256(tickCumulative), 0, "tickCumulative should be positive for ETH/USD");
@@ -92,21 +96,31 @@ contract ChainLinkToV3OracleTest is Test {
 
         // Should match current tick from slot0
         (, int24 currentTick, , , , , ) = oracle.slot0();
-        assertEq(derivedTick, currentTick, "Derived tick from observations should match slot0 tick");
+        assertEq(
+            derivedTick,
+            currentTick,
+            "Derived tick from observations should match slot0 tick"
+        );
     }
 
     function testObserveReturnsValidData() public {
         uint32[] memory secondsAgos = new uint32[](5);
-        secondsAgos[0] = 0;    // now
-        secondsAgos[1] = 60;   // 1 minute ago
-        secondsAgos[2] = 300;  // 5 minutes ago
-        secondsAgos[3] = 600;  // 10 minutes ago
+        secondsAgos[0] = 0; // now
+        secondsAgos[1] = 60; // 1 minute ago
+        secondsAgos[2] = 300; // 5 minutes ago
+        secondsAgos[3] = 600; // 10 minutes ago
         secondsAgos[4] = 1800; // 30 minutes ago
 
-        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = oracle.observe(secondsAgos);
+        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = oracle.observe(
+            secondsAgos
+        );
 
         assertEq(tickCumulatives.length, secondsAgos.length, "Should return same length arrays");
-        assertEq(liquidityCumulatives.length, secondsAgos.length, "Should return same length arrays");
+        assertEq(
+            liquidityCumulatives.length,
+            secondsAgos.length,
+            "Should return same length arrays"
+        );
 
         // All liquidity cumulatives should be 0
         for (uint256 i = 0; i < liquidityCumulatives.length; i++) {
@@ -115,13 +129,17 @@ contract ChainLinkToV3OracleTest is Test {
 
         // Tick cumulatives should be decreasing (older timestamps = smaller cumulatives)
         for (uint256 i = 0; i < tickCumulatives.length - 1; i++) {
-            assertGt(tickCumulatives[i], tickCumulatives[i + 1], "Newer observations should have larger cumulatives");
+            assertGt(
+                tickCumulatives[i],
+                tickCumulatives[i + 1],
+                "Newer observations should have larger cumulatives"
+            );
         }
     }
 
     function testObserveTWAPCalculation() public {
         uint32[] memory secondsAgos = new uint32[](2);
-        secondsAgos[0] = 0;   // now
+        secondsAgos[0] = 0; // now
         secondsAgos[1] = 600; // 10 minutes ago
 
         (int56[] memory tickCumulatives, ) = oracle.observe(secondsAgos);
@@ -136,7 +154,9 @@ contract ChainLinkToV3OracleTest is Test {
 
     function testObserveEmptyArray() public {
         uint32[] memory emptyArray = new uint32[](0);
-        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = oracle.observe(emptyArray);
+        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = oracle.observe(
+            emptyArray
+        );
 
         assertEq(tickCumulatives.length, 0, "Should return empty array");
         assertEq(liquidityCumulatives.length, 0, "Should return empty array");
@@ -148,7 +168,9 @@ contract ChainLinkToV3OracleTest is Test {
             largeArray[i] = uint32(i * 60); // Every minute for 100 minutes
         }
 
-        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = oracle.observe(largeArray);
+        (int56[] memory tickCumulatives, uint160[] memory liquidityCumulatives) = oracle.observe(
+            largeArray
+        );
 
         assertEq(tickCumulatives.length, 100, "Should handle large arrays");
         assertEq(liquidityCumulatives.length, 100, "Should handle large arrays");
@@ -175,7 +197,11 @@ contract ChainLinkToV3OracleTest is Test {
 
         // Values should be the same (since we use current chainlink price)
         (, int24 laterTick, , , , , ) = oracle.slot0();
-        assertEq(laterTick, initialTick, "Tick should be consistent across time (same chainlink round)");
+        assertEq(
+            laterTick,
+            initialTick,
+            "Tick should be consistent across time (same chainlink round)"
+        );
     }
 
     function testChainlinkPriceToTickConversion() public {

--- a/test/foundry/core/PythToV3Oracle.t.sol
+++ b/test/foundry/core/PythToV3Oracle.t.sol
@@ -228,11 +228,7 @@ contract PythToV3OracleTest is Test {
 
         // Values should be the same (since we use current Pyth price)
         (, int24 laterTick, , , , , ) = oracle.slot0();
-        assertEq(
-            laterTick,
-            initialTick,
-            "Tick should be consistent across time (same Pyth round)"
-        );
+        assertEq(laterTick, initialTick, "Tick should be consistent across time (same Pyth round)");
     }
 
     function testPriceComparisonWithUniswapPool() public {

--- a/test/foundry/core/PythToV3Oracle.t.sol
+++ b/test/foundry/core/PythToV3Oracle.t.sol
@@ -2,25 +2,29 @@
 pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
-import "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+import "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
 import "@uniswap/v3-core/contracts/libraries/TickMath.sol";
 import "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
 import {FullMath} from "v3-core/libraries/FullMath.sol";
 
-import "../../../contracts/ChainLinkToV3Oracle.sol";
+import "../../../contracts/PythToV3Oracle.sol";
 
-contract ChainLinkToV3OracleTest is Test {
-    ChainLinkToV3Oracle oracle;
-    AggregatorV3Interface aggregator =
-        AggregatorV3Interface(
-            0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419 // ETH/USD aggregator on mainnet
+contract PythToV3OracleTest is Test {
+    PythToV3Oracle oracle;
+    IPyth pyth =
+        IPyth(
+            // From: https://docs.pyth.network/price-feeds/contract-addresses/evm
+            0x2880aB155794e7179c9eE2e38200202908C17B43 // Pyth on unichain
         );
-    IUniswapV3Pool ethUsdcPool = IUniswapV3Pool(0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640);
+    // From: https://www.pyth.network/developers/price-feed-ids
+    bytes32 ethUsdPriceFeedId = 0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace;
+    // https://uniscan.xyz/address/0x65081CB48d74A32e9CCfED75164b8c09972DBcF1
+    IUniswapV3Pool ethUsdcPool = IUniswapV3Pool(0x65081CB48d74A32e9CCfED75164b8c09972DBcF1);
 
     function setUp() public {
-        uint256 forkId = vm.createFork(vm.envString("MAINNET_RPC_URL"));
+        uint256 forkId = vm.createFork(vm.envString("UNICHAIN_RPC_URL"));
         vm.selectFork(forkId);
-        oracle = new ChainLinkToV3Oracle(aggregator);
+        oracle = new PythToV3Oracle(pyth, ethUsdPriceFeedId);
     }
 
     function testSlot0ReturnsValidPrice() public {
@@ -131,7 +135,7 @@ contract ChainLinkToV3OracleTest is Test {
             );
         }
 
-        // TODO: Test that the TWAP = chainlink price
+        // TODO: Test that the TWAP = Pyth price
     }
 
     function testObserveTWAPCalculation() public {
@@ -200,7 +204,7 @@ contract ChainLinkToV3OracleTest is Test {
 
         assertEq(tickCumulatives.length, 100, "Should handle large arrays");
         assertEq(liquidityCumulatives.length, 100, "Should handle large arrays");
-        // TODO: also test that the tickCumulative is still current chainlink price
+        // TODO: also test that the tickCumulative is still current Pyth price
     }
 
     function testIncreaseObservationCardinalityNext() public {
@@ -222,12 +226,12 @@ contract ChainLinkToV3OracleTest is Test {
         // Fast forward time
         vm.warp(block.timestamp + 1000);
 
-        // Values should be the same (since we use current chainlink price)
+        // Values should be the same (since we use current Pyth price)
         (, int24 laterTick, , , , , ) = oracle.slot0();
         assertEq(
             laterTick,
             initialTick,
-            "Tick should be consistent across time (same chainlink round)"
+            "Tick should be consistent across time (same Pyth round)"
         );
     }
 
@@ -255,7 +259,7 @@ contract ChainLinkToV3OracleTest is Test {
             uint256(poolSqrtPriceX96),
             1 << 192
         );
-        // 3) Match the decimals to chainlink's and flip token order to USD per ETH:
+        // 3) Match the decimals to Pyth's and flip token order to USD per ETH:
         //    USD/ETH = (1 / (WETH/USDC)) = 1e12 / poolRaw
         uint256 poolPrice = FullMath.mulDiv(
             1e12, // numerator
@@ -271,7 +275,7 @@ contract ChainLinkToV3OracleTest is Test {
     }
 
     // TODO
-    function testRevertOnBadChainlinkPrice() public {
+    function testRevertOnBadPythPrice() public {
         // This test would require mocking the aggregator to return bad data
         // For now, we trust that the mainnet ETH/USD feed returns valid data
         // In a more comprehensive test suite, you'd mock this


### PR DESCRIPTION
(Will move this to its own repo eventually, but storing here for now)

A contract that exposes UniV3 price / observation methods, but under the hood gets the data from Pyth

This enables protocols (such as Panoptic v1.1) to read from this contract to drive their logic, even if no fitting Uni v3 pool exists for usage as a price oracle.

Be sure to export a Unichain RPC URL into your shell before running the test (Will swap this over to a foundry.toml value soon - was just trying to get this working)

~Note that we _could_ return actual historical prices in the `observe` call, corresponding to each `secondsAgo`. We'd use the [historical price feed](https://docs.chain.link/data-feeds/historical-data) and search for the round with a timestamp closest to `block.timestamp - secondsAgo[i]`. However, didn't feel necessary to do that yet - we can just use plain old current price to drive PanopticPool logic.~

(The above was true of Chainlink, but is not true of Pyth)

TODO:

[✅] Return a sqrtPrice and currentTick in slot0
[✅] Return observation arrays
[ ] Decide what to do with some arguably-now-useless values, such as `observationCardinalityNext`
[✅] Test